### PR TITLE
Add instrumentation for networking plugins.

### DIFF
--- a/aci/buildroot/buildroot.config
+++ b/aci/buildroot/buildroot.config
@@ -124,31 +124,6 @@ BR2_TOOLCHAIN=y
 BR2_TOOLCHAIN_USES_GLIBC=y
 # BR2_TOOLCHAIN_BUILDROOT is not set
 BR2_TOOLCHAIN_EXTERNAL=y
-# BR2_KERNEL_HEADERS_3_2 is not set
-# BR2_KERNEL_HEADERS_3_4 is not set
-# BR2_KERNEL_HEADERS_3_10 is not set
-# BR2_KERNEL_HEADERS_3_12 is not set
-# BR2_KERNEL_HEADERS_3_14 is not set
-# BR2_KERNEL_HEADERS_3_18 is not set
-# BR2_KERNEL_HEADERS_4_1 is not set
-# BR2_KERNEL_HEADERS_4_2 is not set
-# BR2_KERNEL_HEADERS_4_3 is not set
-# BR2_KERNEL_HEADERS_VERSION is not set
-# BR2_TOOLCHAIN_BUILDROOT_UCLIBC is not set
-# BR2_TOOLCHAIN_BUILDROOT_GLIBC is not set
-# BR2_TOOLCHAIN_BUILDROOT_MUSL is not set
-# BR2_UCLIBC_VERSION_0_9_33 is not set
-# BR2_UCLIBC_VERSION_NG is not set
-# BR2_UCLIBC_VERSION_SNAPSHOT is not set
-# BR2_PTHREADS_NONE is not set
-# BR2_PTHREADS_NATIVE is not set
-# BR2_BINUTILS_VERSION_2_23_X is not set
-# BR2_BINUTILS_VERSION_2_24_X is not set
-# BR2_BINUTILS_VERSION_2_25_X is not set
-# BR2_GCC_VERSION_4_7_X is not set
-# BR2_GCC_VERSION_4_8_X is not set
-# BR2_GCC_VERSION_4_9_X is not set
-# BR2_GCC_VERSION_5_X is not set
 BR2_TOOLCHAIN_EXTERNAL_CODESOURCERY_X86_201209=y
 # BR2_TOOLCHAIN_EXTERNAL_CODESOURCERY_X86_201203 is not set
 # BR2_TOOLCHAIN_EXTERNAL_CODESOURCERY_X86_201109 is not set
@@ -396,7 +371,7 @@ BR2_PACKAGE_CMAKE_ARCH_SUPPORTS=y
 # BR2_PACKAGE_GETTEXT is not set
 # BR2_PACKAGE_GIT is not set
 # BR2_PACKAGE_GPERF is not set
-# BR2_PACKAGE_JQ is not set
+BR2_PACKAGE_JQ=y
 # BR2_PACKAGE_LIBTOOL is not set
 # BR2_PACKAGE_MAKE is not set
 # BR2_PACKAGE_PKGCONF is not set
@@ -1463,35 +1438,35 @@ BR2_PACKAGE_OPENSSH=y
 #
 
 #
-# Please note:
+# Please note:                                           
 #
 
 #
-# - Buildroot does *not* generate binary packages,
+# - Buildroot does *not* generate binary packages,       
 #
 
 #
-# - Buildroot does *not* install any package database.
+# - Buildroot does *not* install any package database.   
 #
 
 #
-# *
+# *                                                      
 #
 
 #
-# It is up to you to provide those by yourself if you
+# It is up to you to provide those by yourself if you    
 #
 
 #
-# want to use any of those package managers.
+# want to use any of those package managers.             
 #
 
 #
-# *
+# *                                                      
 #
 
 #
-# See the manual:
+# See the manual:                                        
 #
 
 #

--- a/aci/cni-netplugin/add.sh
+++ b/aci/cni-netplugin/add.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+set -e
+
+export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+# read stdin
+payload=$(mktemp $TMPDIR/cni-command.XXXXXX)
+cat > $payload <&0
+
+# locate the plugin
+plugin=$(jq -r '.type // ""' < $payload)
+if [ "$plugin" == "" ]; then
+    echo "No CNI plugin specified"
+    exit 1
+fi
+
+export CNI_PATH=/usr/bin
+export CNI_COMMAND=ADD
+export CNI_NETNS=$1
+export CNI_CONTAINERID=$2
+export CNI_IFNAME=$3
+
+$plugin < $payload

--- a/aci/cni-netplugin/build.sh
+++ b/aci/cni-netplugin/build.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+export BASE_PATH=`pwd`
+
+set -e -x
+
+# compile the cni binaries
+cd appc-cni-source
+version=$(git describe --tags)
+./build
+
+mkdir $BASE_PATH/rootfs
+cd $BASE_PATH/rootfs
+
+# copy in cni binaries
+mkdir -p usr/bin
+cp $BASE_PATH/appc-cni-source/bin/* usr/bin/
+# except cnitool
+rm usr/bin/cnitool
+
+# copy in the networking script
+mkdir -p opt/network
+cp $BASE_PATH/kurmaos-source/aci/cni-netplugin/setup.sh opt/network/setup
+cp $BASE_PATH/kurmaos-source/aci/cni-netplugin/add.sh opt/network/add
+cp $BASE_PATH/kurmaos-source/aci/cni-netplugin/del.sh opt/network/del
+chown 0:0 opt/network/*
+chmod a+x opt/network/*
+
+# generate the aci
+cd $BASE_PATH
+acbuild --no-history begin
+for i in $BASE_PATH/rootfs/* ; do
+    j=$(basename $i)
+    acbuild --no-history copy $i $j
+done
+
+acbuild --no-history label add os linux
+acbuild --no-history label add arch amd64
+acbuild --no-history label add version $version
+
+acbuild --no-history set-name apcera.com/kurma/cni-netplugin
+
+depversion=$(go run kurmaos-source/aci/vergetter.go busybox-aci-image/busybox.aci)
+dephash=$(shasum -a 512 busybox-aci-image/busybox.aci | cut -d" " -f1)
+acbuild --no-history dependency add apcera.com/kurma/busybox --label version=$depversion --image-id="sha512-$dephash"
+
+acbuild --no-history write --overwrite cni-netplugin.aci
+acbuild --no-history end

--- a/aci/cni-netplugin/del.sh
+++ b/aci/cni-netplugin/del.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+set -e
+
+export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+# read stdin
+payload=$(mktemp $TMPDIR/cni-command.XXXXXX)
+cat > $payload <&0
+
+# locate the plugin
+plugin=$(jq -r '.type // ""' < $payload)
+if [ "$plugin" == "" ]; then
+    echo "No CNI plugin specified"
+    exit 1
+fi
+
+export CNI_PATH=/usr/bin
+export CNI_COMMAND=DEL
+export CNI_NETNS=$1
+export CNI_CONTAINERID=$2
+export CNI_IFNAME=$3
+
+$plugin < $payload

--- a/aci/cni-netplugin/run.sh
+++ b/aci/cni-netplugin/run.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -e
+
+# Change to the location of the script
+cd $(dirname $0)
+
+# Create the output file ahead of time to ensure it is available.
+output_filename=cni-netplugin.aci
+touch ../../output/$output_filename
+
+docker run --rm \
+       -v `pwd`/../../output/busybox.aci:/tmp/build/busybox-aci-image/busybox.aci \
+       -v `pwd`/../..:/tmp/build/kurmaos-source \
+       -v $GOPATH/src/github.com/appc/cni:/tmp/build/appc-cni-source \
+       -v `pwd`/../../output/$output_filename:/tmp/build/z$output_filename \
+       -w /tmp/build \
+       apcera/kurmaos-stage4 \
+       bash -c "./kurmaos-source/aci/cni-netplugin/build.sh && cp $output_filename z$output_filename"
+
+echo "Compiled output available in output/$output_filename"

--- a/aci/cni-netplugin/setup.sh
+++ b/aci/cni-netplugin/setup.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+# read stdin
+payload=$(mktemp $TMPDIR/cni-command.XXXXXX)
+cat > $payload <&0
+
+# locate the plugin
+plugin=$(jq -r '.type // ""' < $payload)
+if [ "$plugin" == "" ]; then
+    echo "No CNI plugin specified"
+    exit 1
+fi
+
+# check to see if the dhcp daemon should be started
+ipam=$(jq -r '.ipam.type // ""' < $payload)
+if [ "$ipam" == "dhcp" ]; then
+    /usr/bin/dhcp daemon &
+fi
+
+exit 0

--- a/aci/cni-netplugin/task.yml
+++ b/aci/cni-netplugin/task.yml
@@ -1,0 +1,12 @@
+---
+platform: linux
+
+image: docker:///apcera/kurmaos-stage4
+
+inputs:
+  - name: busybox-aci-image
+  - name: appc-cni-source
+  - name: kurmaos-source
+
+run:
+  path: kurmaos-source/aci/cni-netplugin/build.sh

--- a/aci/console/build.sh
+++ b/aci/console/build.sh
@@ -34,8 +34,8 @@ ln -s poweroff rootfs/sbin/reboot
 cp /usr/bin/cgpt rootfs/bin/cgpt
 
 # create a symlink so the console can access kernel modules from the host
-ln -s /host/proc/1/rootfs/lib/firmware rootfs/lib/firmware
-ln -s /host/proc/1/rootfs/lib/modules rootfs/lib/modules
+ln -s /host/proc/1/root/lib/firmware rootfs/lib/firmware
+ln -s /host/proc/1/root/lib/modules rootfs/lib/modules
 
 # generate the aci
 cd $BASE_PATH

--- a/aci/lo-netplugin/build.sh
+++ b/aci/lo-netplugin/build.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+export BASE_PATH=`pwd`
+
+set -e -x
+
+# calculate ldflags for the version number
+version="$(git --git-dir=$BASE_PATH/kurma-source/.git describe --tags | cut -d'-' -f1)+git"
+if [[ -f $BASE_PATH/version/number ]]; then
+    version=$(cat $BASE_PATH/version/number)
+fi
+BUILD_LDFLAGS="-X github.com/apcera/kurma/stage1/client.version=$version"
+
+# setup the gopath
+mkdir -p go/src/github.com/apcera
+ln -s $BASE_PATH/kurma-source go/src/github.com/apcera/kurma
+export GOPATH="$BASE_PATH/go:$BASE_PATH/kurma-source/Godeps/_workspace"
+
+mkdir rootfs
+cd rootfs
+
+# copy in the networking script
+go build -a -o lo-plugin $BASE_PATH/go/src/github.com/apcera/kurma/networking/drivers/lo/main.go
+mkdir -p opt/network
+ln -s ../../lo-plugin opt/network/setup
+ln -s ../../lo-plugin opt/network/add
+ln -s ../../lo-plugin opt/network/del
+
+# setup lib
+mkdir lib
+ln -s lib lib64
+
+# copy needed dynamic libraries
+LD_TRACE_LOADED_OBJECTS=1 ./lo-plugin | grep so | grep -v linux-vdso.so.1 \
+    | sed -e '/^[^\t]/ d' \
+    | sed -e 's/\t//' \
+    | sed -e 's/.*=..//' \
+    | sed -e 's/ (0.*)//' \
+    | xargs -I % cp % lib/
+
+# generate the aci
+cd $BASE_PATH
+acbuild --no-history begin
+for i in $BASE_PATH/rootfs/* ; do
+    j=$(basename $i)
+    acbuild --no-history copy $i $j
+done
+
+acbuild --no-history label add os linux
+acbuild --no-history label add arch amd64
+acbuild --no-history label add version v$version
+
+acbuild --no-history set-exec /opt/network/setup
+acbuild --no-history set-user 0
+acbuild --no-history set-group 0
+acbuild --no-history set-name apcera.com/kurma/lo-netplugin
+
+acbuild --no-history write --overwrite lo-netplugin.aci
+acbuild --no-history end

--- a/aci/lo-netplugin/run.sh
+++ b/aci/lo-netplugin/run.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -e
+
+# Change to the location of the script
+cd $(dirname $0)
+
+# Create the output file ahead of time to ensure it is available.
+output_filename=lo-netplugin.aci
+touch ../../output/$output_filename
+
+docker run --rm \
+       -v `pwd`/../..:/tmp/build/kurmaos-source \
+       -v `pwd`/../../../kurma:/tmp/build/kurma-source \
+       -v `pwd`/../../output/$output_filename:/tmp/build/z$output_filename \
+       -w /tmp/build \
+       apcera/kurmaos-stage4 \
+       bash -c "./kurmaos-source/aci/lo-netplugin/build.sh && cp $output_filename z$output_filename"
+
+echo "Compiled output available in ../../output/$output_filename"

--- a/aci/lo-netplugin/task.yml
+++ b/aci/lo-netplugin/task.yml
@@ -1,0 +1,11 @@
+---
+platform: linux
+
+image: docker:///apcera/kurmaos-stage4
+
+inputs:
+  - name: kurmaos-source
+  - name: kurma-source
+
+run:
+  path: kurmaos-source/aci/lo-netplugin/build.sh

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -29,6 +29,8 @@ groups:
   - kurma-cli
   - kurma-upgrader-aci
   - console-aci
+  - lo-netplugin-aci
+  - cni-netplugin-aci
   - kurma-init
 - name: machines
   jobs:
@@ -282,7 +284,31 @@ jobs:
     - put: kurma-upgrader-aci-image
       params:
         from: kurma-upgrader.aci
-
+- name: lo-netplugin-aci
+  plan:
+    - aggregate:
+      - get: kurmaos-source
+      - get: kurma-source
+      - get: version
+        passed: [ build-it ]
+        trigger: true
+    - task: build
+      file: kurmaos-source/aci/lo-netplugin/task.yml
+    - put: lo-netplugin-aci-image
+      params:
+        from: lo-netplugin.aci
+- name: cni-netplugin-aci
+  plan:
+    - aggregate:
+      - get: kurmaos-source
+      - get: busybox-aci-image
+        passed: [ busybox-aci ]
+      - get: appc-cni-source
+    - task: build
+      file: kurmaos-source/aci/cni-netplugin/task.yml
+    - put: cni-netplugin-aci-image
+      params:
+        from: cni-netplugin.aci
 
 
 
@@ -337,11 +363,15 @@ jobs:
         passed: [ console-aci ]
       - get: kurma-api-aci-image
         passed: [ kurma-api-aci ]
+      - get: lo-netplugin-aci-image
+        passed: [ kurma-lo-netplugin-aci ]
+      - get: cni-netplugin-aci-image
+        passed: [ cni-netplugin-aci ]
       - get: kurma-source
-        passed: [ build-it, console-aci, kurma-api-aci ]
+        passed: [ build-it, console-aci, kurma-api-aci, lo-netplugin-aci ]
       - get: kurmaos-source
       - get: version
-        passed: [ build-it, console-aci, kurma-api-aci ]
+        passed: [ build-it, console-aci, kurma-api-aci, lo-netplugin-aci ]
         trigger: true
     - task: build
       file: kurmaos-source/code/kurma-init/task.yml
@@ -633,6 +663,10 @@ resources:
   type: git
   source:
     uri: https://github.com/apcera/util.git
+- name: appc-cni-source
+  type: git
+  source:
+    uri: https://github.com/appc/cni.git
 
   # Build Artifacts
 - name: buildroot-base
@@ -683,6 +717,22 @@ resources:
     access_key_id: {{aws-access-key}}
     secret_access_key: {{aws-secret-key}}
     versioned_file: aci/kurma-upgrader.aci
+- name: lo-netplugin-aci-image
+  type: s3
+  source:
+    bucket: kurmaos-artifacts
+    region_name: us-west-2
+    access_key_id: {{aws-access-key}}
+    secret_access_key: {{aws-secret-key}}
+    versioned_file: aci/lo-netplugin.aci
+- name: cni-netplugin-aci-image
+  type: s3
+  source:
+    bucket: kurmaos-artifacts
+    region_name: us-west-2
+    access_key_id: {{aws-access-key}}
+    secret_access_key: {{aws-secret-key}}
+    versioned_file: aci/cni-netplugin.aci
 - name: console-aci-image
   type: s3
   source:

--- a/code/kurma-init/build.sh
+++ b/code/kurma-init/build.sh
@@ -32,6 +32,8 @@ cp $BASE_PATH/console-aci-image/console.aci acis/console.aci
 cp $BASE_PATH/ntp-aci-image/ntp.aci acis/ntp.aci
 cp $BASE_PATH/udev-aci-image/udev.aci acis/udev.aci
 cp $BASE_PATH/kurma-api-aci-image/kurma-api.aci acis/kurma-api.aci
+cp $BASE_PATH/lo-netplugin-aci-image/lo-netplugin.aci acis/lo-netplugin.aci
+cp $BASE_PATH/cni-netplugin-aci-image/cni-netplugin.aci acis/cni-netplugin.aci
 
 # configure the init script
 ln -s kurma init

--- a/code/kurma-init/kurma.json
+++ b/code/kurma-init/kurma.json
@@ -14,7 +14,6 @@
     "iptable_filter",
     "veth"
   ],
-  "required_namespaces": [ "mount", "pid" ],
   "disks": [
     { "device": "LABEL=ROOT",
       "fstype": "ext4",
@@ -47,5 +46,26 @@
   },
   "init_containers": [
     "apcera.com/kurma/api"
+  ],
+  "container_networks": [
+    {
+      "name": "lo",
+      "aci": "apcera.com/kurma/lo-netplugin",
+      "containerInterface": "lo"
+    },
+    {
+      "name": "bridge",
+      "aci": "apcera.com/kurma/cni-netplugin",
+      "containerInterface": "veth+{{shortuuid}}",
+      "type": "bridge",
+      "bridge": "bridge0",
+      "isGateway": true,
+      "ipMasq": true,
+      "ipam": {
+        "type": "host-local",
+        "subnet": "10.220.0.0/16",
+        "routes": [ { "dst": "0.0.0.0/0" } ]
+      }
+    }
   ]
 }

--- a/code/kurma-init/run.sh
+++ b/code/kurma-init/run.sh
@@ -17,6 +17,8 @@ docker run --rm \
        -v `pwd`/../../output/ntp.aci:/tmp/build/ntp-aci-image/ntp.aci \
        -v `pwd`/../../output/udev.aci:/tmp/build/udev-aci-image/udev.aci \
        -v `pwd`/../../output/kurma-api.aci:/tmp/build/kurma-api-aci-image/kurma-api.aci \
+       -v `pwd`/../../output/lo-netplugin.aci:/tmp/build/lo-netplugin-aci-image/lo-netplugin.aci \
+       -v `pwd`/../../output/cni-netplugin.aci:/tmp/build/cni-netplugin-aci-image/cni-netplugin.aci \
        -v `pwd`/../../output/$output_filename:/tmp/build/$output_filename \
        -w /tmp/build \
        apcera/kurmaos-kernel \

--- a/code/kurma-init/task.yml
+++ b/code/kurma-init/task.yml
@@ -11,6 +11,8 @@ inputs:
   - name: kurma-api-aci-image
   - name: kurma-source
   - name: kurmaos-source
+  - name: lo-netplugin-aci-image
+  - name: cni-netplugin-aci-image
   - name: version
 
 run:


### PR DESCRIPTION
Adds the building of container images for the default networking
plugins. This includes our own plugin for setting up the loopback
device, as well as a container image for the Container Network
Interface (CNI) networking plugins.

The default Kurma configuration will now instrument a loopback and a
veth device on a bridge, with ip forwarding configured to the host's
interface. This is roughly inline with default behavior for Docker.